### PR TITLE
Fix cookiecutter 1.5 expand abbreviations

### DIFF
--- a/cookiepatcher/main.py
+++ b/cookiepatcher/main.py
@@ -8,7 +8,7 @@ from cookiecutter.config import get_user_config, USER_CONFIG_PATH
 from cookiecutter.generate import generate_context
 from cookiecutter.prompt import prompt_for_config
 from cookiecutter.vcs import clone
-
+import cookiecutter
 if LooseVersion("1.5") <= LooseVersion(cookiecutter.__version__):
     from cookiecutter.repository import expand_abbreviations
 else:

--- a/cookiepatcher/main.py
+++ b/cookiepatcher/main.py
@@ -2,12 +2,18 @@ import argparse
 import json
 import os
 import subprocess
+from distutils.version import LooseVersion
 
 from cookiecutter.config import get_user_config, USER_CONFIG_PATH
 from cookiecutter.generate import generate_context
 from cookiecutter.main import expand_abbreviations
 from cookiecutter.prompt import prompt_for_config
 from cookiecutter.vcs import clone
+
+if LooseVersion("1.5") <= LooseVersion(cookiecutter.__version__):
+    from cookiecutter.repository import expand_abbreviations
+else:
+    from cookiecutter.main import expand_abbreviations
 
 from jinja2 import Template
 

--- a/cookiepatcher/main.py
+++ b/cookiepatcher/main.py
@@ -6,7 +6,6 @@ from distutils.version import LooseVersion
 
 from cookiecutter.config import get_user_config, USER_CONFIG_PATH
 from cookiecutter.generate import generate_context
-from cookiecutter.main import expand_abbreviations
 from cookiecutter.prompt import prompt_for_config
 from cookiecutter.vcs import clone
 

--- a/cookiepatcher/main.py
+++ b/cookiepatcher/main.py
@@ -2,17 +2,12 @@ import argparse
 import json
 import os
 import subprocess
-from distutils.version import LooseVersion
 
 from cookiecutter.config import get_user_config, USER_CONFIG_PATH
 from cookiecutter.generate import generate_context
 from cookiecutter.prompt import prompt_for_config
 from cookiecutter.vcs import clone
-import cookiecutter
-if LooseVersion("1.5") <= LooseVersion(cookiecutter.__version__):
-    from cookiecutter.repository import expand_abbreviations
-else:
-    from cookiecutter.main import expand_abbreviations
+from cookiecutter.repository import expand_abbreviations
 
 from jinja2 import Template
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version='0.1',
     description='A tool to apply updates of cookiecutter templates',
     packages=find_packages(),
-    install_requires=['cookiecutter'],
+    install_requires=['cookiecutter>=1.5.0'],
     entry_points={
         'console_scripts': [
             'cookiepatcher = cookiepatcher.main:cookiepatch'


### PR DESCRIPTION
fix import error when cookiecutter 1.5.

```
  File "xxx/.virtualenvs/python-3.5.1/lib/python3.5/site-packages/cookiepatcher/main.py", line 8, in <module>
    from cookiecutter.main import expand_abbreviations
ImportError: cannot import name 'expand_abbreviations'
```

here is cookiecutter changed commit.

https://github.com/audreyr/cookiecutter/commit/12de75bb23e3f05fb1807b1b5d357cf9cfc0accd

@hirokiky please review.