### PR TITLE
Improve shell compatibility

### DIFF
--- a/cookiepatcher/main.py
+++ b/cookiepatcher/main.py
@@ -77,7 +77,7 @@ def cookiepatch():
 
     rendered = Template(patch_str).render(**context)
     if(rendered):
-            rendered += os.linesep
+        rendered += os.linesep
 
     if args.show:
         print(rendered)

--- a/cookiepatcher/main.py
+++ b/cookiepatcher/main.py
@@ -76,6 +76,8 @@ def cookiepatch():
         context['cookiecutter'] = prompt_for_config(context, no_input)
 
     rendered = Template(patch_str).render(**context)
+    if(rendered):
+            rendered += os.linesep
 
     if args.show:
         print(rendered)


### PR DESCRIPTION
add newline to patch command pipeline. 

please review.

----------------
detail.

patching with cookiepatcher claim `malformed patch` sometimes.
```
cookiepatcher
patching file xxx.py
patch unexpectedly ends in middle of line
patch: **** malformed patch at line 54:
```

but, execute direct cli shell patch(1) commad is success with same context diff.

```
cat xxx.patch | patch -p1 
patching file xxx.py
Hunk #1 succeeded at 20 with fuzz 2 (offset 12 lines).
```

I think `shell redirect` adding newline, maybe.

