### PR TITLE
follow file rename.

### DIFF
--- a/cookiepatcher/main.py
+++ b/cookiepatcher/main.py
@@ -83,7 +83,7 @@ def cookiepatch():
         print(rendered)
         return
 
-    p = subprocess.Popen(['patch',  '-Np1', '--no-backup-if-mismatch'], stdin=subprocess.PIPE,
+    p = subprocess.Popen(['git',  'apply', '-v', '-p1', '--reject'], stdin=subprocess.PIPE,
                          cwd='..')
     p.communicate(rendered.encode())
 


### PR DESCRIPTION
cookiepacher do not respect `git mv` file.
so, use `git apply --reject` insteed of `patch(1)`.

I will send more detail infomation by private channel, later.
because we use cookiepacher for closed project.
